### PR TITLE
Compatibility with javaslang 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.javaslang</groupId>
             <artifactId>javaslang</artifactId>
-            <version>[2.0.0, 3.0.0)</version>
+            <version>2.1.0-alpha</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/github/javactic/Every.java
+++ b/src/main/java/com/github/javactic/Every.java
@@ -1972,7 +1972,7 @@ public interface Every<T> extends Iterable<T>, IntFunction<T> {
    * @return A new Every containing pairs consisting of all elements of this
    *         Every paired with their index. Indices start at 0.
    */
-  default Every<Tuple2<T, Long>> zipWithIndex() {
+  default Every<Tuple2<T, Integer>> zipWithIndex() {
     return fromNonEmptySeq(toVector().zipWithIndex());
   }
 

--- a/src/test/java/com/github/javactic/EveryTest.java
+++ b/src/test/java/com/github/javactic/EveryTest.java
@@ -508,7 +508,7 @@ public class EveryTest {
     assertEquals(Every.of(Tuple.of(1, 5), Tuple.of(2, 9)), e.zipAll(List.of(5), 0, 9));
     assertEquals(Every.of(Tuple.of(1, 5), Tuple.of(2, 6), Tuple.of(0, 7)), e.zipAll(List.of(5, 6, 7), 0, 19));
     Every<String> e2 = Every.of("A", "B");
-    assertEquals(Every.of(Tuple.of("A", 0L), Tuple.of("B", 1L)), e2.zipWithIndex());
+    assertEquals(Every.of(Tuple.of("A", 0), Tuple.of("B", 1)), e2.zipWithIndex());
   }
 
   @Test


### PR DESCRIPTION
Hi

Javaslang 2.1.0 is introducing a change (not considered breaking) that breaks compilation of Every.zipWithIndex(). I suggest fixing the dependency to Javaslang 2.1.0-alpha and fix the problem for the next round of development.

From the Javaslang blog:
"There is one eye-catching API change that is considered backward compatible. We changed collection indices from long to int. Long indices make only sense when processing possibly infinite streams of data. Moreover, some collections only support int indices. Therefore we did a step back here."

See: http://blog.javaslang.io/javaslang-2-1-0-alpha-is-available/

Best Regards
Jörgen